### PR TITLE
Alpha 1.3.0

### DIFF
--- a/src/assets/filter_alt-24px.svg
+++ b/src/assets/filter_alt-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24"><g><path d="M0,0h24 M24,24H0" fill="none"/><path d="M4.25,5.61C6.27,8.2,10,13,10,13v6c0,0.55,0.45,1,1,1h2c0.55,0,1-0.45,1-1v-6c0,0,3.72-4.8,5.74-7.39 C20.25,4.95,19.78,4,18.95,4H5.04C4.21,4,3.74,4.95,4.25,5.61z"/><path d="M0,0h24v24H0V0z" fill="none"/></g></svg>

--- a/src/components/FilterPanel.vue
+++ b/src/components/FilterPanel.vue
@@ -1,12 +1,5 @@
 <template>
   <div class="container">
-    <div class="row">
-      <div class="col">
-      </div>
-      <div class="col text-center">
-        {{visibleCount}} of {{allCount}} recipes
-      </div>
-    </div>
     <div class="row pt-0 pb-3 mt-3 px-0 bg-light">
       <div 
         class="col-12 col-md-4"

--- a/src/components/FilterPanel.vue
+++ b/src/components/FilterPanel.vue
@@ -7,28 +7,33 @@
         {{visibleCount}} of {{allCount}} recipes
       </div>
     </div>
-    <div class="row bg-light pt-1 pb-3 mt-3 custom-overflow">
-      <div class="col-md-6 mb-3">
-        <h4>Meals</h4>
-        <ToggleButton
-          v-for="(filter, idx) in Object.keys(recipeTypes)"
-          :key="idx"
-          :active="recipeTypes[filter].state"
-          @click="emitToggle(filter)"
-          >{{filter}}</ToggleButton>
+    <div class="row pt-1 pb-3 mt-3">
+      <div class="col-8 offset-2 bg-light custom-overflow">
+      <div class="col-12 text-center">
+        <IngredientTagDropdown title="Meals">
+          <ToggleButton
+            v-for="(filter, idx) in Object.keys(recipeTypes)"
+            :key="idx"
+            class="fade-item"
+            :active="recipeTypes[filter].state"
+            @click="emitToggle(filter)"
+            >{{filter}}</ToggleButton>
+        </IngredientTagDropdown>
       </div>
       <div 
-        class="col-md-6 mb-3"
+        class="col-12 text-center"
         v-for="(itag, idx) in Object.keys(itags)"
         :key="idx"
       >
-      <h4>{{itag}}</h4>
+      <IngredientTagDropdown :title="itag">
         <ToggleButton
           v-for="(filter, idy) in itags[itag]"
           :key="idy"
           :active="ingredients[filter].state"
           @click="emitToggle(filter)"
           >{{filter}}</ToggleButton>
+      </IngredientTagDropdown>
+      </div>
       </div>
     </div>
   </div>
@@ -36,6 +41,7 @@
 
 <script>
 import ToggleButton from '@/components/ToggleButton'
+import IngredientTagDropdown from '@/components/IngredientTagDropdown'
 
 export default {
   name: "FilterPanel",
@@ -46,6 +52,7 @@ export default {
   },
   components: {
     ToggleButton,
+    IngredientTagDropdown,
   },
   props: ["filterList", "visibleCount", "allCount"],
   computed: {
@@ -101,7 +108,6 @@ export default {
 
 <style scoped>
 .custom-overflow {
-  height: 74vh;
   overflow-y: scroll;
 }
 h4 {

--- a/src/components/FilterPanel.vue
+++ b/src/components/FilterPanel.vue
@@ -7,22 +7,20 @@
         {{visibleCount}} of {{allCount}} recipes
       </div>
     </div>
-    <div class="row pt-1 pb-3 mt-3">
-      <div class="col-8 offset-2 bg-light custom-overflow">
-        <div 
-          class="col-12 text-center"
-          v-for="(itag, idx) in Object.keys(itags)"
-          :key="idx"
-        >
-          <IngredientTagDropdown :title="itag" :count="countSelected(itag)">
-            <ToggleButton
-              v-for="(filter, idy) in itags[itag]"
-              :key="idy"
-              :active="tags[filter].state"
-              @click="emitToggle(filter)"
-              >{{filter}}</ToggleButton>
-          </IngredientTagDropdown>
-        </div>
+    <div class="row pt-0 pb-3 mt-3 px-0 bg-light">
+      <div 
+        class="col-12 col-md-4"
+        v-for="(itag, idx) in Object.keys(itags)"
+        :key="idx"
+      >
+        <IngredientTagDropdown :title="itag" :count="countSelected(itag)">
+          <ToggleButton
+            v-for="(filter, idy) in itags[itag]"
+            :key="idy"
+            :active="tags[filter].state"
+            @click="emitToggle(filter)"
+            >{{filter}}</ToggleButton>
+        </IngredientTagDropdown>
       </div>
     </div>
   </div>
@@ -58,7 +56,6 @@ export default {
     //  the buttons is received as a prop
     
     Object.entries(this.filterList).forEach(ing => {
-      // NEW
       // merge in recipeTypes as an itag named "meals," and then remove the 
       //  one-off dropdown called 'meals' and it should all Just Work.
       // then: should be able to count active filters generically for each iTag

--- a/src/components/IngredientTagDropdown.vue
+++ b/src/components/IngredientTagDropdown.vue
@@ -1,11 +1,22 @@
 <template>
-  <div @click="toggleDropdown">
-    <h4 class="parent border py-2">
-      {{capitalizedTitle}}
-      <span v-if="count > 0">{{count}} selected</span>
-    </h4>
-    <div class="child" v-if="isDropped" @click.stop>
-        <slot class="fade-item"></slot>
+  <div @click="toggleDropdown" class="container px-0">
+    <div
+      class="row parent border"
+      :class="{'hover-color': isMobile}"
+    >
+      <div class="col-8 pl-2">
+        <h5 class="py-2 my-auto">
+          <span class="close-icon" v-if="isDropped && isMobile">&#8722;</span>
+          <span class="open-icon" v-if="!isDropped && isMobile">&#43;</span>
+          <span class="pl-2">{{capitalizedTitle}}</span>
+        </h5>
+      </div>
+      <div class="col ml-auto">
+        <h6 class="selected-count ml-auto py-2 mt-1 mb-0" v-if="count > 0">{{count}} selected</h6>
+      </div>
+    </div>
+    <div class="row pt-2 px-1" v-if="isDropped || !isMobile" @click.stop>
+      <slot class="fade-item"></slot>
     </div>
   </div>
 </template>
@@ -14,19 +25,30 @@
 export default {
   name: "IngredientTagDropdown",
   computed: {
+    isMobile: function() {
+      return this.windowWidth < 768;
+    },
     capitalizedTitle: function() {
       return this.title[0].toUpperCase() + this.title.slice(1,)
     },
   },
   props: ['title', 'count'],
+  mounted: function() {
+    window.addEventListener('resize', () => {
+      this.windowWidth = window.innerWidth;
+    });
+  },
   data: function() {
     return {
       isDropped: false,
+      windowWidth: window.innerWidth,
     }
   },
   methods: {
     toggleDropdown: function() {
-      this.isDropped = !this.isDropped
+      if (this.isMobile) {
+        this.isDropped = !this.isDropped
+      }
     },
   },
 
@@ -34,16 +56,22 @@ export default {
 </script>
 
 <style scoped>
-.parent:hover {
+.open-icon {
+  color: grey;
+  position: relative;
+  top: -1px;
+}
+.close-icon {
+}
+.selected-count {
+  font-size: 0.9em;
+  color: grey;
+  opacity: 0.9;
+}
+.hover-color:hover {
   background-color: rgba(10,10,10,0.2);
 }
 .parent {
   cursor: pointer;
-}
-.child:hover {
-  background-color: rgba(0,0,0,0);
-}
-.child {
-  cursor: text;
 }
 </style>

--- a/src/components/IngredientTagDropdown.vue
+++ b/src/components/IngredientTagDropdown.vue
@@ -1,0 +1,46 @@
+<template>
+  <div @click="toggleDropdown">
+    <h4 class="parent border py-2">{{capitalizedTitle}}</h4>
+    <div class="child" v-if="isDropped" @click.stop>
+        <slot class="fade-item"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "IngredientTagDropdown",
+  computed: {
+    capitalizedTitle: function() {
+      return this.title[0].toUpperCase() + this.title.slice(1,)
+    },
+  },
+  props: ['title', 'tagList'],
+  data: function() {
+    return {
+      isDropped: false,
+    }
+  },
+  methods: {
+    toggleDropdown: function() {
+      this.isDropped = !this.isDropped
+    },
+  },
+
+};
+</script>
+
+<style scoped>
+.parent:hover {
+  background-color: rgba(10,10,10,0.2);
+}
+.parent {
+  cursor: pointer;
+}
+.child:hover {
+  background-color: rgba(0,0,0,0);
+}
+.child {
+  cursor: text;
+}
+</style>

--- a/src/components/IngredientTagDropdown.vue
+++ b/src/components/IngredientTagDropdown.vue
@@ -1,6 +1,9 @@
 <template>
   <div @click="toggleDropdown">
-    <h4 class="parent border py-2">{{capitalizedTitle}}</h4>
+    <h4 class="parent border py-2">
+      {{capitalizedTitle}}
+      <span v-if="count > 0">{{count}} selected</span>
+    </h4>
     <div class="child" v-if="isDropped" @click.stop>
         <slot class="fade-item"></slot>
     </div>
@@ -15,7 +18,7 @@ export default {
       return this.title[0].toUpperCase() + this.title.slice(1,)
     },
   },
-  props: ['title', 'tagList'],
+  props: ['title', 'count'],
   data: function() {
     return {
       isDropped: false,

--- a/src/components/PaginatedResults.vue
+++ b/src/components/PaginatedResults.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="container">
     <div class="row mb-3">
-      <div class="col mt-auto text-light text-center">
+      <div class="col offset-1">
+        <slot name="filterButtons"></slot>
+      </div>
+      <div class="col mt-auto text-light text-right">
         <button
           type="button"
           class="btn btn-light mr-2"
@@ -15,12 +18,13 @@
           @click="nextPage"
           :disabled="this.pageEnd/this.resultsPerPage >= this.pageCount"
           >&#8594;</button>
-      </div>
-      <div class="col mt-auto mr-auto text-center">
-        {{this.recipeBatch.length}} of {{this.recipeCount}} recipes
+        <span class="text-dark ml-5">
+          {{this.recipeBatch.length}} of {{this.recipeCount}} recipes
+        </span>
       </div>
     </div>
-    <div class="row custom-overflow">
+    <slot name="filterPanel" v-if="isFiltersVisible"></slot>
+    <div class="row custom-overflow" v-else>
       <div
         class="col mb-4"
         align="center"
@@ -41,7 +45,7 @@ export default {
   components: {
     RecipeItem,
   },
-  props: ["recipeBatch", "recipeCount"],
+  props: ["recipeBatch", "recipeCount", "isFiltersVisible"],
   data: function() {
     return {
       resultsPerPage: 25,

--- a/src/components/PaginatedResults.vue
+++ b/src/components/PaginatedResults.vue
@@ -1,25 +1,32 @@
 <template>
   <div class="container">
     <div class="row mb-3">
-      <div class="col offset-1">
+      <div :class="{'col-8' : isFiltersVisible, 'col-2' : !isFiltersVisible}">
         <slot name="filterButtons"></slot>
       </div>
-      <div class="col mt-auto text-light text-right">
+      <div class="col my-auto text-light text-right">
         <button
+          v-if="!isFiltersVisible"
           type="button"
-          class="btn btn-light mr-2"
+          class="btn btn-light mr-0"
           @click="prevPage"
           :disabled="this.pageEnd/this.resultsPerPage <= 1"
           >&#8592;</button>
-        <span>{{this.currentPage}} of {{this.pageCount}}</span>
+        <span v-if="!isFiltersVisible">
+          {{this.currentPage}} of {{this.pageCount}}
+        </span>
         <button
+          v-if="!isFiltersVisible"
           type="button"
-          class="btn btn-light ml-2"
+          class="btn btn-light ml-0"
           @click="nextPage"
           :disabled="this.pageEnd/this.resultsPerPage >= this.pageCount"
           >&#8594;</button>
-        <span class="text-dark ml-5">
-          {{this.recipeBatch.length}} of {{this.recipeCount}} recipes
+        <span
+          class="text-dark"
+          :class="{topFix : !isFiltersVisible}"
+        >
+          {{this.recipeBatch.length}} results
         </span>
       </div>
     </div>
@@ -93,6 +100,10 @@ export default {
 </script>
 
 <style scoped>
+.topFix {
+  position: relative;
+  top: 2px;
+}
 .custom-overflow {
   height: 70vh;
   overflow-y: scroll;

--- a/src/components/ToggleButton.vue
+++ b/src/components/ToggleButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button 
     type="button" 
-    class="btn"
+    class="border mb-2 mx-1 toggleButton"
     :class="{'btn-info': active, 'btn-outline-info': !active}"
     @click="toggleClick"
     >

--- a/src/components/ToggleButton.vue
+++ b/src/components/ToggleButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button 
     type="button" 
-    class="border mb-2 mx-1 toggleButton"
+    class="border-0 br-pill mb-2 mx-1 toggleButton"
     :class="{'btn-info': active, 'btn-outline-info': !active}"
     @click="toggleClick"
     >
@@ -22,6 +22,9 @@ export default {
 </script>
 
 <style scoped>
+.br-pill {
+  border-radius: 15px;
+}
 .btn-outline-info:hover {
   background-color: #fff;
   color: #17a2b8;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -32,9 +32,10 @@
         :recipeBatch="visibleRecipes"
         :recipeCount="Object.keys(all_recipes).length"
       >
+      <!-- filterbutton slot for layout reasons -->
         <template v-slot:filterButtons>
-          <!-- filter buttons -->
           <div>
+            <!-- filter open/close button -->
             <button
               class="btn btn-height"
               :class="{
@@ -44,10 +45,17 @@
               @click="toggleFilterPanel()"
             >
               <img src="../assets/filter_alt-24px.svg">
+              <span
+                class="filterBadge"
+                v-if="selectedFilters.length > 0"
+              >
+               {{selectedFilters.length}}</span>
             </button>
+
+            <!-- clear filters button -->
             <button
               v-if="selectedFilters.length > 0 && isFilterPanelVisible"
-              class="btn bg-light btn-height ml-2"
+              class="btn bg-light btn-height ml-4"
               @click="clearSelectedFilters">
               <span>Clear {{selectedFilters.length}} filters</span>
             </button>
@@ -160,6 +168,15 @@ export default {
 </script>
 
 <style scoped>
+.filterBadge {
+  position: absolute;
+  top: -10px;
+  left: 53px;
+  padding: 1px 8px;
+  border-radius: 50%;
+  background: red;
+  color: white;
+}
 .btn-height {
   height: 45px;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -8,43 +8,10 @@
       </div>
     </div>
 
-    <!-- load recipes + filter buttons -->
-    <div class="row my-3 d-flex justify-space-evenly" align="center">
 
-      <div class="col-6" align="right">
-        <button
-          class="btn"
-          :class="{
-            'btn-info': isFilterPanelVisible, 
-            'btn-light': !isFilterPanelVisible,
-          }"
-          @click="toggleFilterPanel()"
-        >
-          <span>Pick Ingredients</span>
-        </button>
-      </div>
-      <div class="col" align="left" v-if="selectedFilters.length > 0">
-        <button class="btn bg-light" @click="clearSelectedFilters">
-          <span>{{selectedFilters.length}} filters selected</span>
-          <span class="cancelIcon pl-2">&#10006;</span>
-        </button>
-      </div>
-
-    </div>
-
-    <!-- filter panel -->
-    <div class="row" v-if="isFilterPanelVisible">
-      <FilterPanel
-        :filterList="all_filters"
-        :visibleCount="visibleRecipes.length"
-        :allCount="Object.keys(all_recipes).length"
-        @toggleBtn="toggleFilter"
-        @clearBtn="clearSelectedFilters"
-        ></FilterPanel>
-    </div>
 
     <!-- recipe list -->
-    <div class="row" v-if="!isFilterPanelVisible">
+    <div class="row">
       <div 
         v-if="loadingRecipesSpinner"
         class="col-2 mt-5 mx-auto text-light"
@@ -54,9 +21,46 @@
       </div>
       <PaginatedResults
         v-else
+        :isFiltersVisible="isFilterPanelVisible"
         :recipeBatch="visibleRecipes"
         :recipeCount="Object.keys(all_recipes).length"
-      ></PaginatedResults>
+      >
+        <template v-slot:filterButtons>
+          <!-- filter buttons -->
+          <div class="row mt-3 d-flex justify-space-evenly" align="center">
+            <div class="col-4" align="right">
+              <button
+                class="btn"
+                :class="{
+                  'btn-info': isFilterPanelVisible, 
+                  'btn-light': !isFilterPanelVisible,
+                }"
+                @click="toggleFilterPanel()"
+              >
+                <span>Pick Ingredients</span>
+              </button>
+            </div>
+            <div class="col" align="left" v-if="selectedFilters.length > 0">
+              <button class="btn bg-light" @click="clearSelectedFilters">
+                <span>{{selectedFilters.length}} filters selected</span>
+                <span class="cancelIcon pl-2">&#10006;</span>
+              </button>
+            </div>
+          </div>
+        </template>
+        <template v-slot:filterPanel>
+          <!-- filter panel -->
+          <div class="row" v-if="isFilterPanelVisible">
+            <FilterPanel
+              :filterList="all_filters"
+              :visibleCount="visibleRecipes.length"
+              :allCount="Object.keys(all_recipes).length"
+              @toggleBtn="toggleFilter"
+              @clearBtn="clearSelectedFilters"
+              ></FilterPanel>
+          </div>
+        </template>
+      </PaginatedResults>
     </div>
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -8,6 +8,13 @@
       </div>
     </div>
 
+    <!-- subheader -->
+    <div class="row my-3">
+      <div class="col text-center">
+        <h2>Level up your cooking</h2>
+      </div>
+    </div>
+
 
 
     <!-- recipe list -->
@@ -27,38 +34,33 @@
       >
         <template v-slot:filterButtons>
           <!-- filter buttons -->
-          <div class="row mt-3 d-flex justify-space-evenly" align="center">
-            <div class="col-4" align="right">
-              <button
-                class="btn"
-                :class="{
-                  'btn-info': isFilterPanelVisible, 
-                  'btn-light': !isFilterPanelVisible,
-                }"
-                @click="toggleFilterPanel()"
-              >
-                <span>Pick Ingredients</span>
-              </button>
-            </div>
-            <div class="col" align="left" v-if="selectedFilters.length > 0">
-              <button class="btn bg-light" @click="clearSelectedFilters">
-                <span>{{selectedFilters.length}} filters selected</span>
-                <span class="cancelIcon pl-2">&#10006;</span>
-              </button>
-            </div>
+          <div>
+            <button
+              class="btn btn-height"
+              :class="{
+                'btn-info': isFilterPanelVisible, 
+                'btn-light': !isFilterPanelVisible,
+              }"
+              @click="toggleFilterPanel()"
+            >
+              <img src="../assets/filter_alt-24px.svg">
+            </button>
+            <button
+              v-if="selectedFilters.length > 0 && isFilterPanelVisible"
+              class="btn bg-light btn-height ml-2"
+              @click="clearSelectedFilters">
+              <span>Clear {{selectedFilters.length}} filters</span>
+            </button>
           </div>
         </template>
         <template v-slot:filterPanel>
-          <!-- filter panel -->
-          <div class="row" v-if="isFilterPanelVisible">
-            <FilterPanel
-              :filterList="all_filters"
-              :visibleCount="visibleRecipes.length"
-              :allCount="Object.keys(all_recipes).length"
-              @toggleBtn="toggleFilter"
-              @clearBtn="clearSelectedFilters"
-              ></FilterPanel>
-          </div>
+          <FilterPanel
+            :filterList="all_filters"
+            :visibleCount="visibleRecipes.length"
+            :allCount="Object.keys(all_recipes).length"
+            @toggleBtn="toggleFilter"
+            @clearBtn="clearSelectedFilters"
+            ></FilterPanel>
         </template>
       </PaginatedResults>
     </div>
@@ -158,6 +160,12 @@ export default {
 </script>
 
 <style scoped>
+.btn-height {
+  height: 45px;
+}
+.filterButton {
+  font-size: 2em;
+}
 .cancelIcon {
   color: red;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,18 +11,23 @@
     <!-- load recipes + filter buttons -->
     <div class="row my-3 d-flex justify-space-evenly" align="center">
 
-      <div class="col" align="right">
-        <button class="btn bg-light" @click="toggleFilterPanel()">
-          <span v-if="isFilterPanelVisible">
-            Hide Filters
-          </span>
-          <span v-else>
-            Show Filters
-          </span>
+      <div class="col-6" align="right">
+        <button
+          class="btn"
+          :class="{
+            'btn-info': isFilterPanelVisible, 
+            'btn-light': !isFilterPanelVisible,
+          }"
+          @click="toggleFilterPanel()"
+        >
+          <span>Pick Ingredients</span>
         </button>
       </div>
-      <div class="col" align="left">
-        <button class="btn bg-light" @click="clearSelectedFilters">Clear Filters</button>
+      <div class="col" align="left" v-if="selectedFilters.length > 0">
+        <button class="btn bg-light" @click="clearSelectedFilters">
+          <span>{{selectedFilters.length}} filters selected</span>
+          <span class="cancelIcon pl-2">&#10006;</span>
+        </button>
       </div>
 
     </div>
@@ -149,6 +154,9 @@ export default {
 </script>
 
 <style scoped>
+.cancelIcon {
+  color: red;
+}
 img {
 }
 form {

--- a/src/views/RecipeView.vue
+++ b/src/views/RecipeView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h2 class="text-light mx-auto my-5" align="center">{{recipe.name}}</h2>
+    <h2 class="mx-auto my-5" align="center">{{recipe.name}}</h2>
     <div class="row d-flex justify-content-center">
       <div class="col-12 col-md mx-auto">
         <div class="container mb-2">
@@ -25,7 +25,7 @@
     </div>
 
 
-    <div class="row bg-light my-5 py-3">
+    <div class="row bg-light py-3">
       <div class="col-12">
         <h4>Steps:</h4>
       </div>
@@ -36,6 +36,15 @@
         <b>{{Number(idx)+1}}. {{step[0]}}</b>
         <br />
         <span>{{step[1]}}</span>
+      </div>
+    </div>
+    <div class="row mt-1 mb-2 py-1">
+      <div class="col-2">
+        <div class="card bg-grey">
+          <h6 class="text-center my-1">
+            <a :href="recipe.origin">Source</a>
+          </h6>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Major:
- total redesign of FilterPanel, for both desktop and mobile
Minor:
- moved filter show/clear buttons into slots on PaginatedResults, this allows space for a sub-header/landing splash under the hero image. For now there's just some placeholder text, there will be a re-vamp of the welcome/hero stuff later.
- added a notification-badge style display of how many currently selected filters the user has
- clear filters button only shows when filter panel is open, this is required for spacing+alignment issues on mobile
- cut back on unnecessary text to save space